### PR TITLE
Enable osx-arm64 builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -12,10 +12,22 @@ jobs:
         CONFIG: osx_64_r_base4.4
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
       osx_64_r_base4.5:
         CONFIG: osx_64_r_base4.5
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
+        store_build_artifacts: false
+      osx_arm64_r_base4.4:
+        CONFIG: osx_arm64_r_base4.4
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+        store_build_artifacts: false
+      osx_arm64_r_base4.5:
+        CONFIG: osx_arm64_r_base4.5
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables: {}
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,9 +11,11 @@ jobs:
       win_64_r_base4.4:
         CONFIG: win_64_r_base4.4
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
       win_64_r_base4.5:
         CONFIG: win_64_r_base4.5
         UPLOAD_PACKAGES: 'True'
+        store_build_artifacts: false
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/osx_arm64_r_base4.4.yaml
+++ b/.ci_support/osx_arm64_r_base4.4.yaml
@@ -1,0 +1,28 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cran_mirror:
+- https://cran.r-project.org
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '4.4'
+target_platform:
+- osx-arm64

--- a/.ci_support/osx_arm64_r_base4.5.yaml
+++ b/.ci_support/osx_arm64_r_base4.5.yaml
@@ -1,0 +1,28 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '19'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cran_mirror:
+- https://cran.r-project.org
+macos_machine:
+- arm64-apple-darwin20.0.0
+pin_run_as_build:
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+r_base:
+- '4.5'
+target_platform:
+- osx-arm64

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,11 +23,13 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_r_base4.4
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
             DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
           - CONFIG: linux_64_r_base4.5
+            STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             os: ubuntu
             runs_on: ['ubuntu-latest']
@@ -104,7 +106,7 @@ jobs:
       env:
         # default value; make it explicit, as it needs to match with artefact
         # generation below. Not configurable for now, can be revisited later
-        CONDA_BLD_DIR: C:\bld
+        CONDA_BLD_PATH: C:\bld
         MINIFORGE_HOME: ${{ contains(runner.arch, 'ARM') && 'C' || 'D' }}:\Miniforge
         PYTHONUNBUFFERED: 1
         CONFIG: ${{ matrix.CONFIG }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Ignore all files and folders in root
 *
 !/conda-forge.yml
+!.recipe_maintainers.json
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'
 # This also avoids warnings when adding an already-checked file with an ignored parent.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -49,6 +49,9 @@ source run_conda_forge_build_setup
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
+if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]] && [[ "${HOST_PLATFORM}" != linux-* ]] && [[ "${BUILD_WITH_CONDA_DEBUG:-0}" != 1 ]]; then
+    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+fi
 
 
 ( endgroup "Configuring conda" ) 2> /dev/null

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -108,6 +108,10 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
 
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda-build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -62,6 +62,11 @@ if EXIST LICENSE.txt (
     echo Copying feedstock license
     copy LICENSE.txt "recipe\\recipe-scripts-license.txt"
 )
+if NOT [%HOST_PLATFORM%] == [%BUILD_PLATFORM%] (
+    if [%CROSSCOMPILING_EMULATOR%] == [] (
+        set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --no-test"
+    )
+)
 
 if NOT [%flow_run_id%] == [] (
         set "EXTRA_CB_OPTIONS=%EXTRA_CB_OPTIONS% --extra-meta flow_run_id=%flow_run_id% remote_url=%remote_url% sha=%sha%"

--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_r_base4.4</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21674&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-secretbase-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_r_base4.4" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_r_base4.5</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21674&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/r-secretbase-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_r_base4.5" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_r_base4.4</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=21674&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,8 +1,11 @@
 github:
   branch_name: main
   tooling_branch_name: main
+build_platform:
+  osx_arm64: osx_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
 bot:
   automerge: true
+test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,7 +3,7 @@
 
 package:
   name: r-secretbase
-  version: {{ version|replace("-", "_") }}
+  version: "{{ version|replace('-', '_') }}"
 
 source:
   url:


### PR DESCRIPTION
**Summary*:
This enables osx-arm64 builds for r-secretbase by adding the standard conda-forge cross-build configuration and rerendering the feedstock.

**Motivation:** r-targets currently cannot be installed from conda-forge on Apple Silicon because parts of its dependency chain are missing osx-arm64 builds. In addition to r-base64url, r-secretbase is needed for the current CRAN/conda-forge targets stack. Also quotes the rendered package version field to satisfy conda-smithy lint without changing the package version.

**Disclosure:**
This PR was drafted and issued by GPT 5.5